### PR TITLE
fix: address all 6 security findings from Marcus (issue #1) — v0.2.0

### DIFF
--- a/node_modules/.vite/vitest/results.json
+++ b/node_modules/.vite/vitest/results.json
@@ -1,1 +1,1 @@
-{"version":"1.6.1","results":[[":tests/session.test.ts",{"duration":4,"failed":false}],[":tests/index.test.ts",{"duration":3,"failed":false}]]}
+{"version":"1.6.1","results":[[":tests/session.test.ts",{"duration":5,"failed":false}],[":tests/index.test.ts",{"duration":5,"failed":false}]]}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xferops/auth-middleware",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xferops/auth-middleware",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "jose": "^5.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xferops/auth-middleware",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Shared JWT validation middleware for XferOps apps",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,34 @@
 /**
  * @xferops/auth-middleware
- * 
+ *
  * Shared JWT validation middleware for XferOps apps.
  * Validates tokens against the shared AUTH_SECRET.
+ *
+ * v0.1 architecture contract:
+ *   - All tokens are issued by auth.xferops.dev (JWT_ISSUER)
+ *   - All tokens carry audience "xferops" (JWT_AUDIENCE)
+ *   - JWTs carry identity only (sub, email) — never role or name claims
+ *   - Apps resolve permissions from their own databases using AppRole
  */
 
 import { jwtVerify, SignJWT, JWTPayload as JoseJWTPayload } from 'jose';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/**
+ * Issuer and audience for all XferOps JWTs.
+ * Must match the values set by xferops-auth (src/lib/tokens.ts).
+ */
+export const JWT_ISSUER  = 'auth.xferops.dev';
+export const JWT_AUDIENCE = 'xferops';
+
+/**
+ * Default access token TTL — 15 minutes.
+ * Short window limits damage from a stolen token.
+ */
+const DEFAULT_ACCESS_TTL = '15m';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
 
 /**
  * Shared role levels for all XferOps apps.
@@ -14,28 +37,18 @@ import { jwtVerify, SignJWT, JWTPayload as JoseJWTPayload } from 'jose';
  * Each app maintains its own role assignments in its own database and
  * resolves the role for a given userId after validating the JWT.
  *
- * The auth service (xferops-auth) does NOT store or issue roles.
- * JWTs carry identity only (sub, email) — never role claims.
+ * The auth service (xferops-auth) does NOT store or issue roles in JWTs.
  */
 export enum AppRole {
-  ADMIN = 'ADMIN',
+  ADMIN   = 'ADMIN',
   MANAGER = 'MANAGER',
-  MEMBER = 'MEMBER',
-  VIEWER = 'VIEWER',
+  MEMBER  = 'MEMBER',
+  VIEWER  = 'VIEWER',
 }
 
 export interface JWTPayload {
   userId: string;
   email: string;
-  /**
-   * @deprecated Roles are not included in XferOps JWTs as of v0.1.
-   * Each app resolves permissions from its own database using AppRole.
-   */
-  role?: string;
-  /**
-   * @deprecated Name is not included in XferOps JWTs as of v0.1.
-   */
-  name?: string;
   exp?: number;
   iat?: number;
 }
@@ -47,147 +60,122 @@ export interface ValidationResult {
 }
 
 export interface CreateTokenOptions {
-  expiresIn?: string; // e.g., "1h", "7d", "30d"
+  expiresIn?: string; // e.g., "15m", "7d", "30d"
 }
 
-/**
- * Convert our payload to jose's format
- */
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
 function toJosePayload(payload: JWTPayload): JoseJWTPayload {
+  // v0.1: JWTs carry identity only — sub + email.
+  // role and name are intentionally excluded; apps resolve them locally.
   return {
     sub: payload.userId,
     email: payload.email,
-    role: payload.role,
-    name: payload.name,
   };
 }
 
-/**
- * Convert jose payload to our format
- */
 function fromJosePayload(payload: JoseJWTPayload): JWTPayload {
   return {
     userId: payload.sub as string,
     email: payload.email as string,
-    role: payload.role as string | undefined,
-    name: payload.name as string | undefined,
     exp: payload.exp,
     iat: payload.iat,
   };
 }
 
+// ─── Public API ──────────────────────────────────────────────────────────────
+
 /**
- * Validate a JWT token
- * @param token - The JWT token string (without "Bearer " prefix)
- * @param secret - The shared AUTH_SECRET (base64 encoded)
- * @returns ValidationResult with payload if valid
+ * Validate a JWT token.
+ *
+ * Enforces iss=auth.xferops.dev and aud=xferops so tokens from other sources
+ * or with different audience claims are rejected even if the secret matches.
+ *
+ * @param token  - The JWT string (without "Bearer " prefix)
+ * @param secret - The shared AUTH_SECRET
  */
 export async function validateJWT(token: string, secret: string): Promise<ValidationResult> {
   try {
-    // Convert secret to Uint8Array
     const secretKey = new TextEncoder().encode(secret);
 
-    // Verify the token
     const { payload } = await jwtVerify(token, secretKey, {
       algorithms: ['HS256'],
+      issuer:     JWT_ISSUER,
+      audience:   JWT_AUDIENCE,
     });
-
-    // Convert jose payload to our format
-    const jwtPayload = fromJosePayload(payload);
 
     return {
       valid: true,
-      payload: jwtPayload,
+      payload: fromJosePayload(payload),
     };
   } catch (error) {
-    // Determine the error type
     if (error instanceof Error) {
       if (error.message.includes('JWT expired')) {
         return { valid: false, error: 'Token has expired' };
       }
-      if (error.message.includes('invalid')) {
-        return { valid: false, error: 'Invalid token' };
-      }
-      return { valid: false, error: error.message };
+      return { valid: false, error: 'Invalid token' };
     }
     return { valid: false, error: 'Unknown validation error' };
   }
 }
 
 /**
- * Create a JWT token
- * @param payload - The payload to encode
- * @param secret - The shared AUTH_SECRET
- * @param options - Options including expiration
- * @returns The JWT token string
+ * Create a signed JWT token.
+ *
+ * Sets iss=auth.xferops.dev and aud=xferops on every token.
+ * Default TTL is 15 minutes (access token standard).
+ *
+ * @param payload  - Identity payload (userId + email only — no roles)
+ * @param secret   - The shared AUTH_SECRET
+ * @param options  - Optional override for expiresIn
  */
 export async function createJWT(
-  payload: JWTPayload, 
-  secret: string, 
-  options: CreateTokenOptions = {}
+  payload: JWTPayload,
+  secret: string,
+  options: CreateTokenOptions = {},
 ): Promise<string> {
   const secretKey = new TextEncoder().encode(secret);
-  
-  const jwt = new SignJWT(toJosePayload(payload))
+
+  return new SignJWT(toJosePayload(payload))
     .setProtectedHeader({ alg: 'HS256' })
     .setIssuedAt()
-    .setSubject(payload.userId);
-
-  // Set expiration if provided
-  if (options.expiresIn) {
-    jwt.setExpirationTime(options.expiresIn);
-  } else {
-    // Default: 24 hours
-    jwt.setExpirationTime('24h');
-  }
-
-  return jwt.sign(secretKey);
+    .setSubject(payload.userId)
+    .setIssuer(JWT_ISSUER)
+    .setAudience(JWT_AUDIENCE)
+    .setExpirationTime(options.expiresIn ?? DEFAULT_ACCESS_TTL)
+    .sign(secretKey);
 }
 
 /**
- * Create a refresh token (longer expiration)
- * @param payload - The payload to encode
- * @param secret - The shared AUTH_SECRET
- * @returns The refresh token string (30 day expiration)
+ * Create a refresh token (30-day expiration).
  */
 export async function createRefreshToken(
-  payload: JWTPayload, 
-  secret: string
+  payload: JWTPayload,
+  secret: string,
 ): Promise<string> {
   return createJWT(payload, secret, { expiresIn: '30d' });
 }
 
 /**
- * Extract token from Authorization header
- * @param authHeader - The Authorization header value (e.g., "Bearer <token>")
- * @returns The token string, or null if not found
+ * Extract token from an Authorization header.
+ *
+ * @param authHeader - "Bearer <token>" string
+ * @returns The token string, or null if missing/malformed
  */
 export function extractToken(authHeader: string | undefined): string | null {
-  if (!authHeader) {
-    return null;
-  }
-  
+  if (!authHeader) return null;
   const parts = authHeader.split(' ');
-  if (parts.length !== 2 || parts[0] !== 'Bearer') {
-    return null;
-  }
-  
+  if (parts.length !== 2 || parts[0] !== 'Bearer') return null;
   return parts[1];
 }
 
 /**
- * Middleware factory for validating JWT in HTTP requests
- * @param secret - The shared AUTH_SECRET
- * @returns Middleware function
+ * Middleware factory for validating JWTs from Authorization headers.
  */
 export function authMiddleware(secret: string) {
   return async (authHeader: string | undefined): Promise<ValidationResult> => {
     const token = extractToken(authHeader);
-    
-    if (!token) {
-      return { valid: false, error: 'No token provided' };
-    }
-    
+    if (!token) return { valid: false, error: 'No token provided' };
     return validateJWT(token, secret);
   };
 }
@@ -195,9 +183,9 @@ export function authMiddleware(secret: string) {
 // Re-export session utilities
 export * from './session.js';
 
-export default { 
-  validateJWT, 
-  createJWT, 
+export default {
+  validateJWT,
+  createJWT,
   createRefreshToken,
   extractToken,
   authMiddleware,

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,6 +1,6 @@
 /**
  * @xferops/auth-middleware
- * 
+ *
  * Session cookie management for XferOps apps.
  */
 
@@ -14,15 +14,13 @@ export interface SessionConfig {
   secure?: boolean;
   sameSite?: 'lax' | 'strict' | 'none';
   httpOnly?: boolean;
-  maxAge?: number; // seconds
-  refreshThreshold?: number; // seconds before expiry to refresh
+  maxAge?: number;          // seconds
+  refreshThreshold?: number; // seconds before expiry to trigger refresh
 }
 
 export interface SessionData {
   userId: string;
   email: string;
-  role?: string;
-  name?: string;
 }
 
 export interface SessionResult {
@@ -32,31 +30,31 @@ export interface SessionResult {
   shouldRefresh?: boolean;
 }
 
+// ─── Session create / validate ───────────────────────────────────────────────
+
 /**
- * Create a session cookie value
+ * Create a session token (JWT) for the given identity.
  */
 export async function createSession(
   session: SessionData,
-  config: SessionConfig
+  config: SessionConfig,
 ): Promise<string> {
   const payload: JWTPayload = {
     userId: session.userId,
-    email: session.email,
-    role: session.role,
-    name: session.name,
+    email:  session.email,
   };
 
-  return createJWT(payload, config.secret, { 
-    expiresIn: config.maxAge ? `${config.maxAge}s` : '24h' 
+  return createJWT(payload, config.secret, {
+    expiresIn: config.maxAge ? `${config.maxAge}s` : undefined,
   });
 }
 
 /**
- * Validate and parse a session cookie
+ * Validate a session cookie value and return the session data.
  */
 export async function validateSession(
   cookieValue: string | undefined,
-  config: SessionConfig
+  config: SessionConfig,
 ): Promise<SessionResult> {
   if (!cookieValue) {
     return { valid: false, error: 'No session cookie' };
@@ -68,130 +66,116 @@ export async function validateSession(
     return { valid: false, error: result.error };
   }
 
-  // Check if token needs refresh (expiring soon)
   let shouldRefresh = false;
   if (config.refreshThreshold && result.payload.exp) {
     const now = Math.floor(Date.now() / 1000);
-    const timeUntilExpiry = result.payload.exp - now;
-    shouldRefresh = timeUntilExpiry < config.refreshThreshold;
+    shouldRefresh = result.payload.exp - now < config.refreshThreshold;
   }
 
   return {
     valid: true,
     session: {
       userId: result.payload.userId,
-      email: result.payload.email,
-      role: result.payload.role,
-      name: result.payload.name,
+      email:  result.payload.email,
     },
     shouldRefresh,
   };
 }
 
+// ─── Cookie helpers ──────────────────────────────────────────────────────────
+
 /**
- * Get cookie options for Set-Cookie header
+ * Build the attributes portion of a Set-Cookie header.
+ *
+ * HttpOnly and Secure use bare-flag format (RFC 6265 §5.2) — NOT `HttpOnly=true`.
+ * Using `HttpOnly=true` is incorrect per spec; many parsers treat it as an unknown
+ * attribute name and silently drop the security flag.
  */
 export function getCookieOptions(config: SessionConfig): string {
-  const options: string[] = [
-    `Path=${config.path || '/'}`,
-    `HttpOnly=${config.httpOnly !== false ? 'true' : 'false'}`,
-    `Secure=${config.secure !== false ? 'true' : 'false'}`,
-    `SameSite=${config.sameSite || 'lax'}`,
-  ];
+  const parts: string[] = [`Path=${config.path ?? '/'}`];
 
-  if (config.domain) {
-    options.push(`Domain=${config.domain}`);
-  }
+  if (config.secure !== false) parts.push('Secure');
+  if (config.httpOnly !== false) parts.push('HttpOnly');
 
-  if (config.maxAge) {
-    options.push(`Max-Age=${config.maxAge}`);
-  }
+  parts.push(`SameSite=${config.sameSite ?? 'lax'}`);
 
-  return options.join('; ');
+  if (config.domain)  parts.push(`Domain=${config.domain}`);
+  if (config.maxAge)  parts.push(`Max-Age=${config.maxAge}`);
+
+  return parts.join('; ');
 }
 
 /**
- * Create a Set-Cookie header value for session
- * Note: This is a sync version that returns a placeholder - use createSessionCookieString for actual use
- */
-export function createSessionCookie(
-  session: SessionData,
-  config: SessionConfig
-): string {
-  // Note: Use createSessionCookieString for actual token generation
-  // This sync version is a placeholder for API compatibility
-  return `${config.cookieName}=<token>; ${getCookieOptions(config)}`;
-}
-
-/**
- * Create a session cookie (async version)
+ * Create a full Set-Cookie header string (async — uses real token).
  */
 export async function createSessionCookieString(
   session: SessionData,
-  config: SessionConfig
+  config: SessionConfig,
 ): Promise<string> {
   const token = await createSession(session, config);
   return `${config.cookieName}=${token}; ${getCookieOptions(config)}`;
 }
 
 /**
- * Create a cleared session cookie (for logout)
+ * Create a Set-Cookie header that clears the session.
  */
 export function createLogoutCookie(config: SessionConfig): string {
   return `${config.cookieName}=; ${getCookieOptions(config)}; Max-Age=0`;
 }
 
+// ─── Removed: createSessionCookie (sync stub) ───────────────────────────────
+// The old sync createSessionCookie() returned a literal "<token>" placeholder —
+// callers who used it got a broken cookie that silently failed auth.
+// Use createSessionCookieString() (async) instead.
+
+// ─── Cookie parsing ──────────────────────────────────────────────────────────
+
 /**
- * Parse cookie header into key-value map
+ * Parse a Cookie request header into a key-value map.
  */
 export function parseCookieHeader(cookieHeader: string | undefined): Record<string, string> {
-  if (!cookieHeader) {
-    return {};
-  }
+  if (!cookieHeader) return {};
 
   const cookies: Record<string, string> = {};
-  
-  cookieHeader.split(';').forEach((cookie) => {
-    const [name, ...rest] = cookie.split('=');
-    if (name && rest.length > 0) {
-      cookies[name.trim()] = rest.join('=').trim();
-    }
+  cookieHeader.split(';').forEach((pair) => {
+    const [name, ...rest] = pair.split('=');
+    if (name) cookies[name.trim()] = rest.join('=').trim();
   });
-
   return cookies;
 }
 
 /**
- * Extract session from cookie header
+ * Extract and validate a session from a Cookie request header.
  */
 export function getSessionFromHeader(
   cookieHeader: string | undefined,
-  config: SessionConfig
+  config: SessionConfig,
 ): Promise<SessionResult> {
   const cookies = parseCookieHeader(cookieHeader);
-  const sessionCookie = cookies[config.cookieName];
-  return validateSession(sessionCookie, config);
+  return validateSession(cookies[config.cookieName], config);
 }
 
+// ─── Default config ──────────────────────────────────────────────────────────
+
 /**
- * Default config for XferOps apps
+ * Default session config for XferOps apps.
+ * Cookie name matches the access token issued by xferops-auth.
  */
 export const defaultSessionConfig: SessionConfig = {
-  cookieName: '__Secure-authjs.session-token',
-  secret: process.env.AUTH_SECRET || '',
-  path: '/',
-  secure: true,
-  sameSite: 'lax',
-  httpOnly: true,
-  maxAge: 60 * 60 * 24, // 24 hours
-  refreshThreshold: 60 * 15, // 15 minutes
+  cookieName:       '__Secure-xferops.access-token',
+  secret:           process.env.AUTH_SECRET ?? '',
+  path:             '/',
+  secure:           true,
+  sameSite:         'lax',
+  httpOnly:         true,
+  maxAge:           60 * 15,       // 15 minutes (access token TTL)
+  refreshThreshold: 60 * 5,        // refresh when <5 min remaining
 };
 
 export default {
   createSession,
   validateSession,
   getCookieOptions,
-  createSessionCookie,
   createSessionCookieString,
   createLogoutCookie,
   parseCookieHeader,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,108 +1,169 @@
 import { describe, it, expect } from 'vitest';
-import { validateJWT, createJWT, createRefreshToken, extractToken, authMiddleware } from '../src/index';
+import {
+  validateJWT,
+  createJWT,
+  createRefreshToken,
+  extractToken,
+  authMiddleware,
+  JWT_ISSUER,
+  JWT_AUDIENCE,
+} from '../src/index';
 
 const TEST_SECRET = 'test-secret-key-for-testing-purposes-only';
 
 describe('auth-middleware', () => {
+  // ── createJWT ──────────────────────────────────────────────────────────────
+
   describe('createJWT', () => {
-    it('should create a valid JWT token', async () => {
-      const payload = {
-        userId: 'user123',
-        email: 'test@example.com',
-        role: 'admin',
-      };
-      
-      const token = await createJWT(payload, TEST_SECRET);
-      
-      expect(token).toBeDefined();
+    it('creates a valid 3-part JWT', async () => {
+      const token = await createJWT({ userId: 'user123', email: 'test@example.com' }, TEST_SECRET);
       expect(typeof token).toBe('string');
-      expect(token.split('.')).toHaveLength(3); // JWT has 3 parts
+      expect(token.split('.')).toHaveLength(3);
+    });
+
+    it('sets iss and aud claims', async () => {
+      const token = await createJWT({ userId: 'user123', email: 'test@example.com' }, TEST_SECRET);
+      // Decode the payload (middle part) without verifying — just inspect claims
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+      expect(decoded.iss).toBe(JWT_ISSUER);
+      expect(decoded.aud).toBe(JWT_AUDIENCE);
+    });
+
+    it('defaults to 15m expiry', async () => {
+      const before = Math.floor(Date.now() / 1000);
+      const token = await createJWT({ userId: 'user123', email: 'test@example.com' }, TEST_SECRET);
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+      const ttl = decoded.exp - before;
+      // Should be ~15 minutes (900s) — allow ±10s for test timing
+      expect(ttl).toBeGreaterThan(890);
+      expect(ttl).toBeLessThan(910);
+    });
+
+    it('respects custom expiresIn', async () => {
+      const before = Math.floor(Date.now() / 1000);
+      const token = await createJWT(
+        { userId: 'user123', email: 'test@example.com' },
+        TEST_SECRET,
+        { expiresIn: '1h' },
+      );
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+      const ttl = decoded.exp - before;
+      expect(ttl).toBeGreaterThan(3590);
+      expect(ttl).toBeLessThan(3610);
+    });
+
+    it('does not include role or name claims', async () => {
+      const token = await createJWT({ userId: 'user123', email: 'test@example.com' }, TEST_SECRET);
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+      expect(decoded.role).toBeUndefined();
+      expect(decoded.name).toBeUndefined();
     });
   });
+
+  // ── validateJWT ────────────────────────────────────────────────────────────
 
   describe('validateJWT', () => {
-    it('should validate a valid token', async () => {
-      const payload = {
-        userId: 'user123',
-        email: 'test@example.com',
-        role: 'admin',
-      };
-      
-      const token = await createJWT(payload, TEST_SECRET);
+    it('validates a well-formed token', async () => {
+      const token = await createJWT({ userId: 'user123', email: 'test@example.com' }, TEST_SECRET);
       const result = await validateJWT(token, TEST_SECRET);
-      
       expect(result.valid).toBe(true);
-      expect(result.payload).toBeDefined();
       expect(result.payload?.userId).toBe('user123');
       expect(result.payload?.email).toBe('test@example.com');
-      expect(result.payload?.role).toBe('admin');
     });
 
-    it('should reject an invalid token', async () => {
+    it('rejects a malformed token', async () => {
       const result = await validateJWT('invalid.token.here', TEST_SECRET);
-      
       expect(result.valid).toBe(false);
       expect(result.error).toBeDefined();
     });
 
-    it('should reject a token with wrong secret', async () => {
-      const payload = { userId: 'user123', email: 'test@example.com' };
-      const token = await createJWT(payload, TEST_SECRET);
-      
+    it('rejects a token signed with the wrong secret', async () => {
+      const token = await createJWT({ userId: 'user123', email: 'test@example.com' }, TEST_SECRET);
       const result = await validateJWT(token, 'wrong-secret');
-      
       expect(result.valid).toBe(false);
-      expect(result.error).toBeDefined();
+    });
+
+    it('rejects a token with wrong issuer', async () => {
+      // Create a token with a different issuer by signing manually
+      const { SignJWT } = await import('jose');
+      const secretKey = new TextEncoder().encode(TEST_SECRET);
+      const token = await new SignJWT({ email: 'test@example.com' })
+        .setProtectedHeader({ alg: 'HS256' })
+        .setSubject('user123')
+        .setIssuer('https://evil.example.com')
+        .setAudience(JWT_AUDIENCE)
+        .setExpirationTime('15m')
+        .sign(secretKey);
+
+      const result = await validateJWT(token, TEST_SECRET);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects a token with wrong audience', async () => {
+      const { SignJWT } = await import('jose');
+      const secretKey = new TextEncoder().encode(TEST_SECRET);
+      const token = await new SignJWT({ email: 'test@example.com' })
+        .setProtectedHeader({ alg: 'HS256' })
+        .setSubject('user123')
+        .setIssuer(JWT_ISSUER)
+        .setAudience('wrong-audience')
+        .setExpirationTime('15m')
+        .sign(secretKey);
+
+      const result = await validateJWT(token, TEST_SECRET);
+      expect(result.valid).toBe(false);
     });
   });
+
+  // ── createRefreshToken ─────────────────────────────────────────────────────
 
   describe('createRefreshToken', () => {
-    it('should create a refresh token with 30 day expiration', async () => {
-      const payload = { userId: 'user123', email: 'test@example.com' };
-      
-      const token = await createRefreshToken(payload, TEST_SECRET);
-      
-      expect(token).toBeDefined();
-      
-      // Verify the token is valid for longer
+    it('creates a valid token with ~30d expiry', async () => {
+      const before = Math.floor(Date.now() / 1000);
+      const token = await createRefreshToken(
+        { userId: 'user123', email: 'test@example.com' },
+        TEST_SECRET,
+      );
       const result = await validateJWT(token, TEST_SECRET);
       expect(result.valid).toBe(true);
+
+      const decoded = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+      const ttlDays = (decoded.exp - before) / 86400;
+      expect(ttlDays).toBeGreaterThan(29.9);
+      expect(ttlDays).toBeLessThan(30.1);
     });
   });
+
+  // ── extractToken ───────────────────────────────────────────────────────────
 
   describe('extractToken', () => {
-    it('should extract token from Bearer header', () => {
-      const token = extractToken('Bearer my-token-123');
-      expect(token).toBe('my-token-123');
+    it('extracts token from Bearer header', () => {
+      expect(extractToken('Bearer my-token-123')).toBe('my-token-123');
     });
 
-    it('should return null for missing header', () => {
-      const token = extractToken(undefined);
-      expect(token).toBeNull();
+    it('returns null for missing header', () => {
+      expect(extractToken(undefined)).toBeNull();
     });
 
-    it('should return null for non-Bearer header', () => {
-      const token = extractToken('Basic auth-token');
-      expect(token).toBeNull();
+    it('returns null for non-Bearer scheme', () => {
+      expect(extractToken('Basic auth-token')).toBeNull();
     });
   });
 
+  // ── authMiddleware ─────────────────────────────────────────────────────────
+
   describe('authMiddleware', () => {
-    it('should validate token from Authorization header', async () => {
-      const payload = { userId: 'user123', email: 'test@example.com' };
-      const token = await createJWT(payload, TEST_SECRET);
-      
+    it('validates a token from Authorization header', async () => {
+      const token = await createJWT({ userId: 'user123', email: 'test@example.com' }, TEST_SECRET);
       const middleware = authMiddleware(TEST_SECRET);
       const result = await middleware(`Bearer ${token}`);
-      
       expect(result.valid).toBe(true);
       expect(result.payload?.userId).toBe('user123');
     });
 
-    it('should reject missing token', async () => {
+    it('rejects a missing token', async () => {
       const middleware = authMiddleware(TEST_SECRET);
       const result = await middleware(undefined);
-      
       expect(result.valid).toBe(false);
       expect(result.error).toBe('No token provided');
     });

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,136 +1,171 @@
 import { describe, it, expect } from 'vitest';
-import { 
-  createSession, 
-  validateSession, 
-  createSessionCookieString, 
+import {
+  createSession,
+  validateSession,
+  createSessionCookieString,
   createLogoutCookie,
   parseCookieHeader,
   getCookieOptions,
   defaultSessionConfig,
-  type SessionConfig 
+  type SessionConfig,
 } from '../src/session';
 
 const TEST_CONFIG: SessionConfig = {
-  cookieName: 'test-session',
-  secret: 'test-secret-key-for-testing',
-  path: '/',
-  secure: true,
-  sameSite: 'lax',
-  httpOnly: true,
-  maxAge: 3600,
+  cookieName:       'test-session',
+  secret:           'test-secret-key-for-testing',
+  path:             '/',
+  secure:           true,
+  sameSite:         'lax',
+  httpOnly:         true,
+  maxAge:           3600,
   refreshThreshold: 300,
 };
 
 describe('session management', () => {
+  // ── createSession ──────────────────────────────────────────────────────────
+
   describe('createSession', () => {
-    it('should create a valid session token', async () => {
-      const session = {
-        userId: 'user123',
-        email: 'test@example.com',
-        role: 'admin',
-      };
-
-      const token = await createSession(session, TEST_CONFIG);
-
-      expect(token).toBeDefined();
+    it('creates a valid 3-part JWT', async () => {
+      const token = await createSession(
+        { userId: 'user123', email: 'test@example.com' },
+        TEST_CONFIG,
+      );
       expect(typeof token).toBe('string');
       expect(token.split('.')).toHaveLength(3);
     });
   });
 
+  // ── validateSession ────────────────────────────────────────────────────────
+
   describe('validateSession', () => {
-    it('should validate a valid session', async () => {
-      const session = {
-        userId: 'user123',
-        email: 'test@example.com',
-        role: 'admin',
-      };
-
-      const token = await createSession(session, TEST_CONFIG);
+    it('validates a valid session', async () => {
+      const token = await createSession(
+        { userId: 'user123', email: 'test@example.com' },
+        TEST_CONFIG,
+      );
       const result = await validateSession(token, TEST_CONFIG);
-
       expect(result.valid).toBe(true);
-      expect(result.session).toBeDefined();
       expect(result.session?.userId).toBe('user123');
       expect(result.session?.email).toBe('test@example.com');
-      expect(result.session?.role).toBe('admin');
     });
 
-    it('should reject an invalid session', async () => {
+    it('rejects an invalid token', async () => {
       const result = await validateSession('invalid-token', TEST_CONFIG);
-
       expect(result.valid).toBe(false);
       expect(result.error).toBeDefined();
     });
 
-    it('should return error for missing cookie', async () => {
+    it('returns error for missing cookie', async () => {
       const result = await validateSession(undefined, TEST_CONFIG);
-
       expect(result.valid).toBe(false);
       expect(result.error).toBe('No session cookie');
     });
-  });
 
-  describe('createSessionCookieString', () => {
-    it('should create a valid cookie string', async () => {
-      const session = {
-        userId: 'user123',
-        email: 'test@example.com',
-      };
-
-      const cookieString = await createSessionCookieString(session, TEST_CONFIG);
-
-      expect(cookieString).toContain('test-session=');
-      expect(cookieString).toContain('HttpOnly=true');
-      expect(cookieString).toContain('Secure=true');
-      expect(cookieString).toContain('SameSite=lax');
-      expect(cookieString).toContain('Path=/');
+    it('does not include role or name in session result', async () => {
+      const token = await createSession(
+        { userId: 'user123', email: 'test@example.com' },
+        TEST_CONFIG,
+      );
+      const result = await validateSession(token, TEST_CONFIG);
+      expect(result.valid).toBe(true);
+      expect((result.session as any)?.role).toBeUndefined();
+      expect((result.session as any)?.name).toBeUndefined();
     });
   });
 
-  describe('createLogoutCookie', () => {
-    it('should create a cookie that clears the session', () => {
-      const cookie = createLogoutCookie(TEST_CONFIG);
+  // ── getCookieOptions ───────────────────────────────────────────────────────
 
+  describe('getCookieOptions', () => {
+    it('uses bare HttpOnly and Secure flags (RFC 6265)', () => {
+      const options = getCookieOptions(TEST_CONFIG);
+      // Bare flags — NOT "HttpOnly=true"
+      expect(options).toContain('HttpOnly');
+      expect(options).not.toContain('HttpOnly=true');
+      expect(options).toContain('Secure');
+      expect(options).not.toContain('Secure=true');
+    });
+
+    it('includes Path and SameSite', () => {
+      const options = getCookieOptions(TEST_CONFIG);
+      expect(options).toContain('Path=/');
+      expect(options).toContain('SameSite=lax');
+    });
+
+    it('includes Domain when provided', () => {
+      const options = getCookieOptions({ ...TEST_CONFIG, domain: '.xferops.dev' });
+      expect(options).toContain('Domain=.xferops.dev');
+    });
+
+    it('omits HttpOnly and Secure when disabled', () => {
+      const options = getCookieOptions({ ...TEST_CONFIG, secure: false, httpOnly: false });
+      expect(options).not.toContain('Secure');
+      expect(options).not.toContain('HttpOnly');
+    });
+
+    it('includes Max-Age when configured', () => {
+      const options = getCookieOptions(TEST_CONFIG);
+      expect(options).toContain('Max-Age=3600');
+    });
+  });
+
+  // ── createSessionCookieString ──────────────────────────────────────────────
+
+  describe('createSessionCookieString', () => {
+    it('creates a valid Set-Cookie string', async () => {
+      const cookie = await createSessionCookieString(
+        { userId: 'user123', email: 'test@example.com' },
+        TEST_CONFIG,
+      );
       expect(cookie).toContain('test-session=');
+      expect(cookie).toContain('HttpOnly');
+      expect(cookie).toContain('Secure');
+      expect(cookie).toContain('SameSite=lax');
+      expect(cookie).toContain('Path=/');
+      // Value should be a real JWT, not a placeholder
+      const tokenPart = cookie.split(';')[0].replace('test-session=', '');
+      expect(tokenPart.split('.')).toHaveLength(3);
+    });
+  });
+
+  // ── createLogoutCookie ─────────────────────────────────────────────────────
+
+  describe('createLogoutCookie', () => {
+    it('creates a cookie that clears the session', () => {
+      const cookie = createLogoutCookie(TEST_CONFIG);
+      expect(cookie).toContain('test-session=;');
       expect(cookie).toContain('Max-Age=0');
     });
   });
 
-  describe('parseCookieHeader', () => {
-    it('should parse a cookie header', () => {
-      const header = 'cookie1=value1; cookie2=value2; cookie3=value3';
-      const cookies = parseCookieHeader(header);
+  // ── parseCookieHeader ──────────────────────────────────────────────────────
 
-      expect(cookies['cookie1']).toBe('value1');
-      expect(cookies['cookie2']).toBe('value2');
-      expect(cookies['cookie3']).toBe('value3');
+  describe('parseCookieHeader', () => {
+    it('parses a multi-value cookie header', () => {
+      const cookies = parseCookieHeader('a=1; b=2; c=3');
+      expect(cookies['a']).toBe('1');
+      expect(cookies['b']).toBe('2');
+      expect(cookies['c']).toBe('3');
     });
 
-    it('should handle empty header', () => {
-      const cookies = parseCookieHeader(undefined);
-      expect(Object.keys(cookies)).toHaveLength(0);
+    it('handles cookies with = in the value (e.g. base64)', () => {
+      const cookies = parseCookieHeader('token=abc.def==');
+      expect(cookies['token']).toBe('abc.def==');
+    });
+
+    it('returns empty object for undefined header', () => {
+      expect(parseCookieHeader(undefined)).toEqual({});
     });
   });
 
-  describe('getCookieOptions', () => {
-    it('should generate correct cookie options', () => {
-      const options = getCookieOptions(TEST_CONFIG);
+  // ── defaultSessionConfig ───────────────────────────────────────────────────
 
-      expect(options).toContain('Path=/');
-      expect(options).toContain('HttpOnly=true');
-      expect(options).toContain('Secure=true');
-      expect(options).toContain('SameSite=lax');
+  describe('defaultSessionConfig', () => {
+    it('uses the xferops access token cookie name', () => {
+      expect(defaultSessionConfig.cookieName).toBe('__Secure-xferops.access-token');
     });
 
-    it('should include domain when provided', () => {
-      const configWithDomain: SessionConfig = {
-        ...TEST_CONFIG,
-        domain: '.xferops.dev',
-      };
-
-      const options = getCookieOptions(configWithDomain);
-      expect(options).toContain('Domain=.xferops.dev');
+    it('has 15m maxAge (matches access token TTL)', () => {
+      expect(defaultSessionConfig.maxAge).toBe(900);
     });
   });
 });


### PR DESCRIPTION
Closes #1

## Summary

Addresses all 6 findings from Marcus's security review of @xferops/auth-middleware v0.1.1.

## Changes

### 🔴 HIGH — validateJWT: enforce issuer + audience
`jwtVerify` now requires `iss=auth.xferops.dev` and `aud=xferops`. A token signed with the correct AUTH_SECRET but from a different issuer or with a different audience is rejected. Two new tests verify rejection of wrong-issuer and wrong-audience tokens.

### 🔴 HIGH — createJWT: default TTL 24h → 15m
Access tokens should be short-lived. 24h was a significant exposure window. Changed to 15 minutes to match xferops-auth's token issuance. Custom `expiresIn` still supported for refresh tokens (createRefreshToken uses 30d).

### 🟡 MEDIUM — toJosePayload: remove role/name from JWT
v0.1 architecture: JWTs carry identity only (sub + email). role and name fields removed from `toJosePayload` and from the `JWTPayload` interface. Apps resolve permissions from their own DB. Tests updated accordingly.

### 🟡 MEDIUM — getCookieOptions: bare flags per RFC 6265
`HttpOnly=true` and `Secure=true` are incorrect per spec. Many cookie parsers treat them as unknown attribute names and silently drop the security flag. Fixed to output bare `; HttpOnly` and `; Secure`.

### 🟡 MEDIUM — createSessionCookie sync stub: removed
The sync `createSessionCookie()` returned a literal `<token>` placeholder. Any caller who accidentally used it instead of `createSessionCookieString()` got a broken cookie with no error. Removed entirely — use `createSessionCookieString()` (async).

### 🔵 LOW — createJWT: set iss + aud claims
Tokens created via this package now carry `iss` and `aud` so they pass validation on any service enforcing issuer/audience (including xferops-auth after PR #12).

### Additional
- `defaultSessionConfig.cookieName` updated to `__Secure-xferops.access-token` (matches actual cookie name issued by xferops-auth)
- `defaultSessionConfig.maxAge` updated to 900s (15m) to match access token TTL

## Tests
33 tests, all passing. New tests added for:
- iss/aud rejection in validateJWT
- Default 15m TTL in createJWT
- Role/name exclusion from JWT payload
- Bare HttpOnly/Secure flags in getCookieOptions
- maxAge and cookieName in defaultSessionConfig

## Breaking changes (v0.2.0)
- `JWTPayload.role` and `JWTPayload.name` removed
- `createSessionCookie()` (sync stub) removed — use `createSessionCookieString()`
- `validateJWT` now rejects tokens without correct iss/aud
- Default token TTL changed from 24h to 15m